### PR TITLE
Date Taken as DateTimeOffset

### DIFF
--- a/api/src/graphql/models/exif_meta.rs
+++ b/api/src/graphql/models/exif_meta.rs
@@ -65,7 +65,7 @@ impl From<ExifMetaModel> for ExifMeta {
             id: value.id.into(),
             rating: value.details.rating.0.into(),
             city: value.details.city.map(|c| c.0),
-            date_taken: value.details.date_taken.map(|d| d.0),
+            date_taken: value.details.date_taken.map(|d| format!("{}", d.0)),
             iso: value.details.iso.0,
             focal_length: FocalLength {
                 value: value.details.focal_length.value,

--- a/api/src/graphql/models/photo.rs
+++ b/api/src/graphql/models/photo.rs
@@ -57,14 +57,6 @@ impl Photo {
 
 impl From<CorePhoto> for Photo {
     fn from(photo: CorePhoto) -> Self {
-        // let date_taken = if let Some(d) = photo.date_taken {
-        //     let format = format_description::parse("[year]-[month]-[day]").unwrap();
-        //     let formatted = d.format(&format).unwrap();
-        //     Some(formatted)
-        // } else {
-        //     None
-        // };
-
         Photo {
             id: photo.id.into(),
             title: photo.title,

--- a/core/src/models/exif_meta/from_exif/date_taken.rs
+++ b/core/src/models/exif_meta/from_exif/date_taken.rs
@@ -1,6 +1,9 @@
 use crate::exif::{ExifData, FindExifData, FromExifData};
 use crate::models::exif_meta::DateTaken;
 use log::debug;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use time::{Date, Month, OffsetDateTime, Time, UtcOffset};
 
 impl FromExifData for DateTaken {
     fn from_exif(data: &[ExifData]) -> Option<Self> {
@@ -8,10 +11,45 @@ impl FromExifData for DateTaken {
 
         debug!("DateTaken::from_exif: {:?}", exif);
 
-        // let value = OffsetDateTime::parse(exif.value());
-        // let value: OffsetDateTime = exif.try_into().ok()?;
+        static RE: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(r"(?<date>[0-9]{4}[-:][09]{2}[-:][0-9]{2}) (?<time>[0-9]{2}:[0-9]{2}:[0-9]{2}).*(?<offset>[+\-0-9]{3}:[0-9]{2})").unwrap()
+        });
+        static RE_DATE: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(r"(?<year>[0-9]{4})[-:](?<month>[09]{2})[-:](?<day>[0-9]{2})").unwrap()
+        });
+        static RE_TIME: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(r"(?<hour>[0-9]{2}):(?<minute>[0-9]{2}):(?<second>[0-9]{2})").unwrap()
+        });
+        static RE_OFFSET: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r"(?<hour>[+\-0-9]{3}):(?<minute>[0-9]{2})").unwrap());
 
-        Some(DateTaken(exif.value().to_string()))
+        let caps = RE.captures(exif.value())?;
+        let date = &caps["date"];
+        let time = &caps["time"];
+        let offset = &caps["offset"];
+
+        let date_caps = RE_DATE.captures(date)?;
+        let year = date_caps["year"].parse::<i32>().ok()?;
+        let month = date_caps["month"].parse::<i32>().ok()?;
+        let day = date_caps["day"].parse::<i32>().ok()?;
+
+        let time_caps = RE_TIME.captures(time)?;
+        let hour = time_caps["hour"].parse::<i32>().ok()?;
+        let minute = time_caps["minute"].parse::<i32>().ok()?;
+        let second = time_caps["second"].parse::<i32>().ok()?;
+
+        let offset_caps = RE_OFFSET.captures(offset)?;
+        let hour_offset = offset_caps["hour"].parse::<i32>().ok()?;
+        let minute_offset = offset_caps["minute"].parse::<i32>().ok()?;
+
+        let date = Date::from_calendar_date(year, Month::try_from(month as u8).unwrap(), day as u8)
+            .ok()?;
+        let time = Time::from_hms(hour as u8, minute as u8, second as u8).ok()?;
+        let offset = UtcOffset::from_hms(hour_offset as i8, minute_offset as i8, 0).ok()?;
+
+        let value = OffsetDateTime::new_in_offset(date, time, offset);
+
+        Some(DateTaken(value))
     }
 }
 
@@ -25,11 +63,26 @@ mod tests {
             "DateTimeOriginal",
             "2024:09:12 18:55:14.13+02:00",
         )];
+        let date = Date::from_calendar_date(2024, Month::September, 12).unwrap();
+        let time = Time::from_hms(18, 55, 14).unwrap();
+        let offset = UtcOffset::from_hms(2, 0, 0).unwrap();
+        let date_time = OffsetDateTime::new_in_offset(date, time, offset);
 
-        assert_eq!(
-            DateTaken::from_exif(&exif),
-            Some(DateTaken("2024:09:12 18:55:14.13+02:00".to_string()))
-        );
+        assert_eq!(DateTaken::from_exif(&exif), Some(DateTaken(date_time)));
+    }
+
+    #[test]
+    fn it_parses_with_negative_offset() {
+        let exif: Vec<ExifData> = vec![ExifData::new(
+            "DateTimeOriginal",
+            "2024:09:12 18:55:14.13-07:30",
+        )];
+        let date = Date::from_calendar_date(2024, Month::September, 12).unwrap();
+        let time = Time::from_hms(18, 55, 14).unwrap();
+        let offset = UtcOffset::from_hms(-7, 30, 0).unwrap();
+        let date_time = OffsetDateTime::new_in_offset(date, time, offset);
+
+        assert_eq!(DateTaken::from_exif(&exif), Some(DateTaken(date_time)));
     }
 
     #[test]

--- a/core/src/models/exif_meta/from_exif/photography_details.rs
+++ b/core/src/models/exif_meta/from_exif/photography_details.rs
@@ -62,8 +62,8 @@ impl FromExifData for PhotographyDetails {
 
 #[cfg(test)]
 mod tests {
-    use time::{Date, Month, OffsetDateTime, Time, UtcOffset};
     use super::*;
+    use time::{Date, Month, OffsetDateTime, Time, UtcOffset};
 
     #[test]
     fn it_parses_photography_details_from_exif() {

--- a/core/src/models/exif_meta/from_exif/photography_details.rs
+++ b/core/src/models/exif_meta/from_exif/photography_details.rs
@@ -62,6 +62,7 @@ impl FromExifData for PhotographyDetails {
 
 #[cfg(test)]
 mod tests {
+    use time::{Date, Month, OffsetDateTime, Time, UtcOffset};
     use super::*;
 
     #[test]
@@ -80,12 +81,17 @@ mod tests {
             ExifData::new("Make", "FUJIFILM"),
         ];
 
+        let date = Date::from_calendar_date(2024, Month::September, 12).unwrap();
+        let time = Time::from_hms(18, 55, 14).unwrap();
+        let offset = UtcOffset::from_hms(2, 0, 0).unwrap();
+        let date_time = OffsetDateTime::new_in_offset(date, time, offset);
+
         assert_eq!(
             PhotographyDetails::from_exif(&exif),
             Some(PhotographyDetails {
                 rating: Rating(3),
                 city: Some(City("Berlin".to_string())),
-                date_taken: Some(DateTaken("2024:09:12 18:55:14.13+02:00".to_string())),
+                date_taken: Some(DateTaken(date_time)),
                 camera_name: "X-T5".to_string(),
                 lens_name: Some("XF23mmF1.4 R LM WR".to_string()),
                 aperture: Aperture(2.8),

--- a/core/src/models/exif_meta/mod.rs
+++ b/core/src/models/exif_meta/mod.rs
@@ -4,7 +4,7 @@ pub mod str;
 
 use serde::{Deserialize, Serialize};
 use strum_macros::Display as EnumDisplay;
-// use time::OffsetDateTime;
+use time::OffsetDateTime;
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ExifMeta {
@@ -32,7 +32,7 @@ pub struct PhotographyDetails {
 pub struct Rating(pub i8);
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct DateTaken(pub String);
+pub struct DateTaken(pub OffsetDateTime);
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct City(pub String);


### PR DESCRIPTION
Properly parse date as a date. From DB into Model was easy, but from Exiftool some trickery was needed. I initially tried to use the `parse` utilities from the `time` crate, but it is tricky to implement a custom format. I opted for regex as is more flexible, although more verbose.