### PR TITLE
Photos Cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,9 +844,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
 ]

--- a/api/src/bootstrap/mod.rs
+++ b/api/src/bootstrap/mod.rs
@@ -5,7 +5,7 @@ use rocket::tokio;
 use std::collections::HashSet;
 
 pub fn prepare_images(state: AppState, tags: Vec<String>) -> tokio::task::JoinHandle<AppState> {
-    let sizes = vec![ImageSize::Hd, ImageSize::Md, ImageSize::Sm];
+    let sizes = [ImageSize::Hd, ImageSize::Md, ImageSize::Sm];
 
     tokio::spawn(async move {
         let mut conn = state.db_pool.acquire().await.unwrap();

--- a/api/src/bootstrap/mod.rs
+++ b/api/src/bootstrap/mod.rs
@@ -1,10 +1,6 @@
 use crate::AppState;
 use core_victorhqc_com::aws::image_size::ImageSize;
-use core_victorhqc_com::{
-    aws::S3,
-    models::{photo::Photo, tag::Tag},
-    sqlx::SqlitePool,
-};
+use core_victorhqc_com::models::{photo::Photo, tag::Tag};
 use rocket::tokio;
 use std::collections::HashSet;
 

--- a/api/src/bootstrap/mod.rs
+++ b/api/src/bootstrap/mod.rs
@@ -1,1 +1,48 @@
-pub mod photos;
+use crate::AppState;
+use core_victorhqc_com::aws::image_size::ImageSize;
+use core_victorhqc_com::{
+    aws::S3,
+    models::{photo::Photo, tag::Tag},
+    sqlx::SqlitePool,
+};
+use rocket::tokio;
+use std::collections::HashSet;
+
+pub fn prepare_images(state: AppState, tags: Vec<String>) -> tokio::task::JoinHandle<AppState> {
+    let sizes = vec![ImageSize::Hd, ImageSize::Md, ImageSize::Sm];
+
+    tokio::spawn(async move {
+        let mut conn = state.db_pool.acquire().await.unwrap();
+        let tags: Vec<&str> = tags.iter().map(|t| t.as_str()).collect();
+
+        let tags = Tag::find_by_names(&mut conn, &tags).await.unwrap();
+        let tag_ids = tags.into_iter().map(|t| t.id).collect::<Vec<_>>();
+
+        let photos: Vec<(String, Photo)> =
+            Photo::find_by_tag_ids(&mut conn, &tag_ids).await.unwrap();
+        let photos: Vec<Photo> = photos.into_iter().map(|(_, p)| p).collect();
+
+        debug!("Bootstrapping {} images", photos.len());
+
+        // Removes repeated photos.
+        let photos_set: HashSet<Photo> = HashSet::from_iter(photos);
+
+        for photo in photos_set {
+            for img_size in sizes.iter() {
+                let response = state
+                    .s3
+                    .download_from_aws_s3((&photo, img_size))
+                    .await
+                    .unwrap();
+
+                let data = response.body.collect().await.unwrap();
+                let bytes = data.into_bytes().to_vec();
+                state.img_cache.save(&photo.id, img_size, bytes.clone());
+
+                debug!("Cached Photo {} in {}", &photo.id, img_size);
+            }
+        }
+
+        state
+    })
+}

--- a/api/src/bootstrap/photos.rs
+++ b/api/src/bootstrap/photos.rs
@@ -1,5 +1,0 @@
-use std::path::Path;
-
-struct Photos {
-    src: Path,
-}

--- a/api/src/cache/image_cache.rs
+++ b/api/src/cache/image_cache.rs
@@ -1,0 +1,43 @@
+use core_victorhqc_com::aws::image_size::ImageSize;
+use std::sync::{Arc, Mutex};
+
+pub type CachedImage = (PhotoId, ImageSize, Vec<u8>);
+pub type PhotoId = String;
+
+pub struct ImageCache {
+    images: Arc<Mutex<Vec<CachedImage>>>,
+}
+
+impl Default for ImageCache {
+    fn default() -> Self {
+        ImageCache {
+            images: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl ImageCache {
+    pub fn get(&self, id: &PhotoId, size: &ImageSize) -> Option<Vec<u8>> {
+        let images = self.images.lock().unwrap();
+        let index = images.iter().position(|(i, s, _)| i == id && s == size);
+
+        match index {
+            None => None,
+            Some(i) => {
+                let image = images.get(i).map(|(_, _, v)| v.clone());
+
+                image
+            }
+        }
+    }
+
+    pub fn save(&self, id: &PhotoId, size: &ImageSize, data: Vec<u8>) {
+        let mut images = self.images.lock().unwrap();
+        let index = images.iter().position(|(i, s, _)| i == id && s == size);
+
+        match index {
+            Some(i) => images[i].2 = data,
+            None => images.push((id.clone(), size.clone(), data)),
+        }
+    }
+}

--- a/api/src/cache/mod.rs
+++ b/api/src/cache/mod.rs
@@ -1,0 +1,1 @@
+pub mod image_cache;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate rocket;
 
+use crate::cache::image_cache::ImageCache;
 use crate::graphql::{
     context::Context,
     graph::RootSchema,
@@ -19,6 +20,7 @@ use log::info;
 use rocket::tokio::spawn;
 use snafu::prelude::*;
 
+mod cache;
 mod graphql;
 mod routes;
 
@@ -51,6 +53,7 @@ async fn main() -> Result<(), Error> {
 
     let context = Context::default(db_pool.clone());
     let loader = AppLoader::default(db_pool.clone());
+    let img_cache = ImageCache::default();
 
     let schema: RootSchema = Schema::build(RootQuery::default(), EmptyMutation, EmptySubscription)
         .data(context)
@@ -65,7 +68,11 @@ async fn main() -> Result<(), Error> {
 
     rocket
         .manage(schema)
-        .manage(AppState { db_pool, s3 })
+        .manage(AppState {
+            db_pool,
+            s3,
+            img_cache,
+        })
         .mount(
             "/",
             routes![index, graphql_query, graphql_request, graphql_playground],
@@ -83,6 +90,7 @@ async fn main() -> Result<(), Error> {
 
 struct AppState {
     db_pool: SqlitePool,
+    img_cache: ImageCache,
     s3: S3,
 }
 

--- a/api/src/routes/images.rs
+++ b/api/src/routes/images.rs
@@ -43,7 +43,7 @@ pub async fn get_image(
     }
 
     let response = s3
-        .download_from_aws_s3((&photo, img_size.clone()))
+        .download_from_aws_s3((&photo, &img_size))
         .await
         .context(GetAWSObjectSnafu)?;
 

--- a/cli/src/photo/upload.rs
+++ b/cli/src/photo/upload.rs
@@ -7,9 +7,9 @@ use snafu::prelude::*;
 
 pub async fn upload(photo: &Photo, s3: &S3, buffers: ImageBuffers) -> Result<(), Error> {
     let (result_hd, result_md, result_sm) = futures::join!(
-        s3.upload_to_aws_s3((photo, ImageSize::Hd), buffers.hd),
-        s3.upload_to_aws_s3((photo, ImageSize::Md), buffers.md),
-        s3.upload_to_aws_s3((photo, ImageSize::Sm), buffers.sm),
+        s3.upload_to_aws_s3((photo, &ImageSize::Hd), buffers.hd),
+        s3.upload_to_aws_s3((photo, &ImageSize::Md), buffers.md),
+        s3.upload_to_aws_s3((photo, &ImageSize::Sm), buffers.sm),
     );
 
     result_hd.context(UploadSnafu {

--- a/core/src/aws/image_size.rs
+++ b/core/src/aws/image_size.rs
@@ -2,7 +2,7 @@ use snafu::Snafu;
 use std::str::FromStr;
 use strum_macros::Display;
 
-#[derive(Debug, Display)]
+#[derive(Debug, Display, Clone, PartialEq)]
 pub enum ImageSize {
     Hd,
     Md,

--- a/core/src/aws/photo.rs
+++ b/core/src/aws/photo.rs
@@ -7,11 +7,10 @@ use aws_sdk_s3::{
         get_object::{GetObjectError, GetObjectOutput},
         put_object::{PutObjectError, PutObjectOutput},
     },
-    primitives::ByteStream,
 };
 use snafu::prelude::*;
 
-pub use aws_sdk_s3::primitives::ByteStreamError;
+pub use aws_sdk_s3::primitives::{ByteStream, ByteStreamError};
 
 impl S3 {
     pub async fn upload_to_aws_s3(

--- a/core/src/aws/photo.rs
+++ b/core/src/aws/photo.rs
@@ -15,7 +15,7 @@ pub use aws_sdk_s3::primitives::{ByteStream, ByteStreamError};
 impl S3 {
     pub async fn upload_to_aws_s3(
         &self,
-        data: (&Photo, ImageSize),
+        data: (&Photo, &ImageSize),
         buffer: Vec<u8>,
     ) -> Result<PutObjectOutput, Error> {
         let body = ByteStream::from(buffer);
@@ -32,7 +32,7 @@ impl S3 {
 
     pub async fn download_from_aws_s3(
         &self,
-        data: (&Photo, ImageSize),
+        data: (&Photo, &ImageSize),
     ) -> Result<GetObjectOutput, Error> {
         self.client
             .get_object()
@@ -44,7 +44,7 @@ impl S3 {
     }
 }
 
-fn key((photo, size): (&Photo, ImageSize)) -> String {
+fn key((photo, size): (&Photo, &ImageSize)) -> String {
     format!("{}_{}", photo.id, size)
 }
 

--- a/core/src/models/photo/mod.rs
+++ b/core/src/models/photo/mod.rs
@@ -4,6 +4,7 @@ mod str;
 use log::debug;
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
+use std::hash::{Hash, Hasher};
 use std::path::Path;
 use std::str::FromStr;
 use str::filetype::Error as FiletypeError;
@@ -46,6 +47,20 @@ impl Photo {
             updated_at,
             deleted: false,
         })
+    }
+}
+
+impl PartialEq for Photo {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for Photo {}
+
+impl Hash for Photo {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
     }
 }
 

--- a/core/src/models/tag/db.rs
+++ b/core/src/models/tag/db.rs
@@ -34,6 +34,15 @@ impl Tag {
         Ok(tag.clone())
     }
 
+    pub async fn find_by_names(
+        conn: &mut SqliteConnection,
+        names: &[&str],
+    ) -> Result<Vec<Tag>, Error> {
+        let tags = find_by_names(conn, names).await?;
+
+        Ok(tags)
+    }
+
     pub async fn find_by_name_or_create(
         conn: &mut SqliteConnection,
         name: &str,


### PR DESCRIPTION
## Description

Caches Images to reduce AWS S3 fees.

1. Caches photos on request, if the image-size combination is not cached it's stored in memory. If it's in the cache, then the request to AWS is skipped.
2. Caches photos on bootstrap. This to avoid initial loading for the main images.

## Known Issues

The current implementation has many problems, the ones I'm aware are:

1. Memory can grow infinitely: This could cause the droplet to run out of memory, for now this is not an issue since I won't be caching hundred of thousand of images. If this happens, then it should be addressed later.
3. The photo is no longer streamed from AWS to the response: Since I'm a Rust newbie, I could not make it work as I wanted, ideally I would be able to stream the bytes from AWS into the browser and at the same time, save the image into the cache as well. But the current approach first downloads the full image and stores it in memory and in the cache, and then is sent to the response. This does not bother me as much as it should, since the images will be cached from the get-go.

