### PR TITLE
fix: cleanup events on navigation

### DIFF
--- a/web/public/one_photo.js
+++ b/web/public/one_photo.js
@@ -2,6 +2,7 @@
   if (!window.__active_collection__ || !window.__open_photo__) return;
 
   document.title = `victorhqc.com - ${window.__open_photo__.photo.title}`;
+  CLEANUP_EXISTING_LISTENERS();
 
   registerKeyboardNavigation();
   registerIconToggle();
@@ -49,11 +50,9 @@
       htmx
         .ajax("GET", ac.ajax_path, {
           source: `li[data-collection="${ac.name}"]`,
-          target: ".portfolio__photos",
+          target: ".portfolio__photos-wrapper",
         })
-        .then(() => {
-          cleanupListeners(listeners);
-        });
+        .then(CLEANUP_EXISTING_LISTENERS);
     };
 
     const listenerRightArrow = (e) => {
@@ -72,54 +71,31 @@
       htmx
         .ajax("GET", prevPath, {
           source: ".prev-photo-ref",
-          target: ".portfolio__photos",
+          target: ".portfolio__photos-wrapper",
         })
-        .then(() => {
-          cleanupListeners(listeners);
-        });
+        .then(CLEANUP_EXISTING_LISTENERS);
     };
 
     const goNext = () => {
       htmx
         .ajax("GET", nextPath, {
           source: ".next-photo-ref",
-          target: ".portfolio__photos",
+          target: ".portfolio__photos-wrapper",
         })
-        .then(() => {
-          cleanupListeners(listeners);
-        });
-    };
-
-    const registerArrows = () => {
-      const left = document.querySelector(".photo-info__left-arrow");
-      const right = document.querySelector(".photo-info__right-arrow");
-
-      if (!left || !right) return;
-
-      left.addEventListener("click", goPrev);
-      right.addEventListener("click", goNext);
+        .then(CLEANUP_EXISTING_LISTENERS);
     };
 
     const listeners = [
-      listenerEsc,
-      listenerRightArrow,
-      listenerLeftArrow,
-      listenerSpace,
+      [listenerEsc, "keyup", document],
+      [listenerRightArrow, "keyup", document],
+      [listenerLeftArrow, "keyup", document],
+      [listenerSpace, "keyup", document],
     ];
 
-    registerArrows();
     addListeners(listeners);
   }
 
-  function cleanupListeners(listeners) {
-    for (const listener of listeners) {
-      document.removeEventListener("keyup", listener);
-    }
-  }
-
   function addListeners(listeners) {
-    for (const listener of listeners) {
-      document.addEventListener("keyup", listener);
-    }
+    listeners.forEach(REGISTER_LISTENER);
   }
 })();

--- a/web/src/routes/context.rs
+++ b/web/src/routes/context.rs
@@ -1,5 +1,6 @@
 use crate::{state::AppState, TEMPLATES};
 use actix_web::{web, ResponseError, Result};
+use log::error;
 use snafu::prelude::*;
 use strum_macros::Display;
 use tera::Context;
@@ -41,8 +42,12 @@ pub enum Error {
 impl ResponseError for Error {
     fn error_response(&self) -> actix_web::HttpResponse {
         match self {
-            Error::Template { source, route } => actix_web::HttpResponse::InternalServerError()
-                .body(format!("{}: {}", route, source)),
+            Error::Template { source, route } => {
+                error!("Failed to render route {}: {:?}", route, source);
+
+                actix_web::HttpResponse::InternalServerError()
+                    .body(format!("{}: {}", route, source))
+            }
         }
     }
 }

--- a/web/templates/_ajax/one_photo.html
+++ b/web/templates/_ajax/one_photo.html
@@ -1,11 +1,29 @@
 {% import "_components/open_photo.html" as c %}
 
-<div class="next-photo-ref" hx-push-url="/photography/{{ collection_route.name }}/{{ photo.next_id }}"></div>
 <div class="prev-photo-ref" hx-push-url="/photography/{{ collection_route.name }}/{{ photo.prev_id }}"></div>
+<div class="next-photo-ref" hx-push-url="/photography/{{ collection_route.name }}/{{ photo.next_id }}"></div>
+<nav class="photo-info__navigation">
+  <ol>
+    <li>
+      <button
+        class="photo-info__left-arrow"
+        hx-get="/one_photo/{{ collection_route.name }}/{{ photo.prev_id }}"
+        hx-push-url="/photography/{{ collection_route.name }}/{{ photo.prev_id }}"
+        hx-target=".portfolio__photos-wrapper"
+      >Prev</button>
+    </li>
+    <li>
+      <button
+        class="photo-info__right-arrow"
+        hx-get="/one_photo/{{ collection_route.name }}/{{ photo.next_id }}"
+        hx-push-url="/photography/{{ collection_route.name }}/{{ photo.next_id }}"
+        hx-target=".portfolio__photos-wrapper"
+      >Next</button>
+    </li>
+  </ol>
+</nav>
 <div class="photo-card__wrapper">
-  <div class="relative">
-    {{ c::open_photo(data=photo.photo, size="Hd") }}
-  </div>
+  {{ c::open_photo(data=photo.photo, size="Hd") }}
 </div>
 
 <script>

--- a/web/templates/_ajax/portfolio_collection.html
+++ b/web/templates/_ajax/portfolio_collection.html
@@ -1,6 +1,6 @@
 {% import "_components/simple_photo.html" as c %}
 
-<ul>
+<ul class="portfolio__photos-collection">
   {% for data in portfolio_photos %}
   <li>{{ c::simple_photo(data=data, size="Sm", class="portfolio__photo") }}</li>
   {% endfor %}
@@ -14,4 +14,10 @@
 
   window.__active_collection__ = {{ collection_route | json_encode() | safe }};
 })();
+</script>
+<script>
+  (function() {
+    CLEANUP_EXISTING_LISTENERS();
+  })();
+
 </script>

--- a/web/templates/_blocks/base.html
+++ b/web/templates/_blocks/base.html
@@ -19,6 +19,22 @@
       {% block dev_head %}{% endblock %}
     {% endif %}
     <script src="/static/htmx.js.gz"></script>
+    <script>
+    let __LISTENERS__ = [];
+
+    function CLEANUP_EXISTING_LISTENERS() {
+      __LISTENERS__.forEach(([listener, type, target]) => {
+        target.removeEventListener(type, listener);
+      });
+
+      __LISTENERS__ = [];
+    }
+
+    function REGISTER_LISTENER([listener, type, target]) {
+      target.addEventListener(type, listener)
+      __LISTENERS__.push([listener, type, target]);
+    }
+    </script>
   </head>
   <body>
     {% block content %}{% endblock %}

--- a/web/templates/_components/open_photo.html
+++ b/web/templates/_components/open_photo.html
@@ -1,15 +1,5 @@
 {% macro open_photo(data, size="Md", class="") %}
 {% set exif = data.exifMeta %}
-<nav class="photo-info__navigation">
-  <ol>
-    <li>
-      <button class="photo-info__left-arrow">Prev</button>
-    </li>
-    <li>
-      <button class="photo-info__right-arrow">Next</button>
-    </li>
-  </ol>
-</nav>
 <div class="photo-wrapper open__photo">
   <div class="photo__container photo--visible">
     <img

--- a/web/templates/_components/portfolio_menu.html
+++ b/web/templates/_components/portfolio_menu.html
@@ -8,7 +8,7 @@
       <li
         hx-get="{{ collection.ajax_path }}"
         hx-push-url="{{ collection.path }}"
-        hx-target=".portfolio__photos"
+        hx-target=".portfolio__photos-wrapper"
         data-collection="{{collection.name}}"
         class="portfolio__collection-item">
           {{ collection.name }}

--- a/web/templates/_components/simple_photo.html
+++ b/web/templates/_components/simple_photo.html
@@ -6,7 +6,7 @@
     alt="{{ data.photo.title }}"
     hx-get="/one_photo/{{ collection_route.name }}/{{ data.photo.id }}"
     hx-push-url="/photography/{{ collection_route.name }}/{{ data.photo.id }}"
-    hx-target=".portfolio__photos"
+    hx-target=".portfolio__photos-wrapper"
   />
 </div>
 {% endmacro simple_photo %}

--- a/web/templates/photo.html
+++ b/web/templates/photo.html
@@ -7,13 +7,11 @@
 
 {% block static_head %}
   <script src="/static/portfolio.css"></script>
-  <script src="/static/photo.css"></script>
   <script src="/static/styles.css"></script>
 {% endblock static_head %}
 
 {% block tailwind_styles %}
   {% include "portfolio.css" %}
-  {% include "photo.css" %}
   {% include "styles.css" %}
 {% endblock tailwind_styles %}
 
@@ -25,8 +23,8 @@
 {{ a::main_menu(show_title=True) }}
 <div class="portfolio__main">
   {{ m::portfolio_menu(collections=available_collections) }}
-  <section class="portfolio__photos">
-    {% include "_ajax/one_photo.html" %}
+  <section class="portfolio__photos-wrapper">
+  {% include "_ajax/one_photo.html" %}
   </section>
 <div>
 {% endblock content %}

--- a/web/templates/portfolio.css
+++ b/web/templates/portfolio.css
@@ -16,11 +16,11 @@
   @apply mt-3;
 }
 
-.portfolio__photos {
+.portfolio__photos-wrapper {
   @apply col-span-1 md:col-span-3 lg:col-span-3;
 }
 
-.portfolio__photos > ul {
+.portfolio__photos-collection {
   @apply grid grid-cols-1 md:grid-cols-4 lg:grid-cols-4 gap-4;
 }
 

--- a/web/templates/portfolio.html
+++ b/web/templates/portfolio.html
@@ -24,12 +24,13 @@
 {% endblock scripts %}
 
 {% block content %}
-
 {{ a::main_menu(show_title=True) }}
 <div class="portfolio__main">
   {{ m::portfolio_menu(collections=available_collections) }}
-  <section class="portfolio__photos">
-    {% include "_ajax/portfolio_collection.html" %}
+  <section class="portfolio__photos-wrapper">
+    <div class="portfolio__photos">
+      {% include "_ajax/portfolio_collection.html" %}
+    </div>
   </section>
 <div>
 {% endblock content %}


### PR DESCRIPTION
The events were being cleaned up when navigating within the open photo page, but when going into a different collection, the event listeners were not cleaned up