### PR TITLE
Cache images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,7 @@ dependencies = [
  "core-victorhqc-com",
  "dotenvy",
  "log",
+ "md5",
  "once_cell",
  "pretty_env_logger",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ core-victorhqc-com = { path = "core" }
 
 dotenvy = "0.15.7"
 log = "0.4.22"
+md5 = "0.7.0"
 pretty_env_logger = "0.5.0"
 rand = "0.8.5"
 regex = "1.11.0"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -10,6 +10,7 @@ async-graphql-rocket = "7.0.10"
 core-victorhqc-com.workspace = true
 dotenvy.workspace = true
 log.workspace = true
+md5.workspace = true
 once_cell = "1.20.1"
 pretty_env_logger.workspace = true
 regex.workspace = true

--- a/api/src/cache/image_cache.rs
+++ b/api/src/cache/image_cache.rs
@@ -1,7 +1,7 @@
 use core_victorhqc_com::aws::{
     image_size::ImageSize,
     photo::{ByteStreamError, Error as AWSError},
-    ByteStream, S3,
+    S3,
 };
 use core_victorhqc_com::models::photo::Photo;
 use rocket::futures::lock::{Mutex, MutexGuard};
@@ -9,7 +9,34 @@ use snafu::prelude::*;
 use std::iter::Iterator;
 use std::sync::Arc;
 
-pub type CachedImage = (PhotoId, ImageSize, Vec<u8>);
+pub struct CachedImage {
+    id: PhotoId,
+    size: ImageSize,
+    bytes: Vec<u8>,
+    md5_hash: String,
+}
+
+impl CachedImage {
+    pub fn new(id: PhotoId, size: ImageSize, bytes: Vec<u8>) -> Self {
+        let md5_hash = format!("{:x}", md5::compute(&bytes));
+
+        Self {
+            id,
+            size,
+            bytes,
+            md5_hash,
+        }
+    }
+
+    pub fn save_bytes(&mut self, bytes: Vec<u8>) {
+        self.bytes = bytes;
+    }
+
+    pub fn get_md5(&self) -> String {
+        self.md5_hash.clone()
+    }
+}
+
 pub type PhotoId = String;
 
 #[derive(Clone)]
@@ -17,6 +44,7 @@ pub struct ImageCache {
     pub s3: S3,
     images: Arc<Mutex<Vec<CachedImage>>>,
 }
+
 impl ImageCache {
     pub fn default(s3: S3) -> Self {
         ImageCache {
@@ -25,11 +53,17 @@ impl ImageCache {
         }
     }
 
-    pub async fn stream(&self, photo: Photo, size: &ImageSize) -> Result<ByteStream, Error> {
+    pub async fn md5_exists(&self, value: &str) -> bool {
+        let images = self.images.lock().await;
+
+        images.iter().any(|p| p.md5_hash == value)
+    }
+
+    pub async fn get(&self, photo: Photo, size: &ImageSize) -> Result<(String, Vec<u8>), Error> {
         let mut images = self.images.lock().await;
         let index = images
             .iter()
-            .position(|(i, s, _)| i == &photo.id && s == size);
+            .position(|p| p.id == photo.id && &p.size == size);
 
         match index {
             None => {
@@ -44,15 +78,17 @@ impl ImageCache {
                 let data = response.body.collect().await.context(StreamSnafu)?;
                 let bytes = data.into_bytes().to_vec();
 
-                // TODO: Save Image while streaming
-                self.inner_save(&photo.id, size, bytes.clone(), &mut images);
-                Ok(ByteStream::from(bytes))
+                let hash = self.inner_save(&photo.id, size, bytes.clone(), &mut images);
+                Ok((hash, bytes))
             }
             Some(i) => {
                 // TODO: Could this be done without cloning the image?
-                let bytes = images.get(i).map(|(_, _, v)| v.clone()).unwrap();
+                let (hash, bytes) = images
+                    .get(i)
+                    .map(|p| (p.get_md5(), p.bytes.clone()))
+                    .unwrap();
 
-                Ok(ByteStream::from(bytes))
+                Ok((hash, bytes))
             }
         }
     }
@@ -69,12 +105,22 @@ impl ImageCache {
         size: &ImageSize,
         data: Vec<u8>,
         images: &mut MutexGuard<'_, Vec<CachedImage>>,
-    ) {
-        let index = images.iter().position(|(i, s, _)| i == id && s == size);
+    ) -> String {
+        let index = images.iter().position(|p| &p.id == id && &p.size == size);
 
         match index {
-            Some(i) => images[i].2 = data,
-            None => images.push((id.clone(), size.clone(), data)),
+            Some(i) => {
+                images[i].save_bytes(data);
+                images[i].get_md5()
+            }
+            None => {
+                let cached = CachedImage::new(id.clone(), size.clone(), data);
+                let hash = cached.get_md5();
+
+                images.push(cached);
+
+                hash
+            }
         }
     }
 }

--- a/api/src/routes/images.rs
+++ b/api/src/routes/images.rs
@@ -21,10 +21,10 @@ use snafu::prelude::*;
 use std::io::Cursor;
 use std::str::FromStr;
 
-#[get("/images/<id>/<size>")]
+#[get("/images/<size>/<id>")]
 pub async fn get_image(
-    id: &str,
     size: &str,
+    id: &str,
     state: &State<AppState>,
 ) -> Result<(Status, (ContentType, ByteStream![Bytes])), Error> {
     let pool = &state.db_pool;

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -12,7 +12,7 @@ dotenvy.workspace = true
 graphql_client = "0.14.0"
 lazy_static = "1.5.0"
 log.workspace = true
-md5 = "0.7.0"
+md5.workspace = true
 pretty_env_logger.workspace = true
 rand = { workspace = true, features = ["alloc"] }
 reqwest = { version = "0.12.9", features = ["json"] }

--- a/web/templates/_components/open_photo.html
+++ b/web/templates/_components/open_photo.html
@@ -3,7 +3,7 @@
   <div class="open-photo__container photo-wrapper">
     <img
       class="photo"
-      src="{{ api_host }}/v1/images/{{ data.id }}/{{ size }}"
+      src="{{ api_host }}/v1/images/{{ size }}/{{ data.id }}"
       alt="{{ data.title }}"
     />
   </div>
@@ -17,7 +17,7 @@
     <div class="open-photo__photo-wrapper photo--visible">
       <img
         class="photo"
-        src="{{ api_host }}/v1/images/{{ data.id }}/{{ size }}"
+        src="{{ api_host }}/v1/images/{{ size }}/{{ data.id }}"
         alt="{{ data.title }}"
       />
     </div>
@@ -25,7 +25,7 @@
       <div class="open-photo__info-photo-wrapper">
         <img
           class="open-photo__info_photo"
-          src="{{ api_host }}/v1/images/{{ data.id }}/{{ size }}"
+          src="{{ api_host }}/v1/images/{{ size }}/{{ data.id }}"
           alt="{{ data.title }}"
         />
       </div>

--- a/web/templates/_components/photo.html
+++ b/web/templates/_components/photo.html
@@ -2,7 +2,7 @@
 <div class="photo-wrapper {{ class }}">
   <img
     class="photo"
-    src="{{ api_host }}/v1/images/{{ data.id }}/{{ size }}"
+    src="{{ api_host }}/v1/images/{{ size }}/{{ data.id }}"
     alt="{{ data.title }}"
   />
   <div class="photo-description">

--- a/web/templates/_components/simple_photo.html
+++ b/web/templates/_components/simple_photo.html
@@ -2,7 +2,7 @@
 <div class="photo-wrapper {{ class }}">
   <img
     class="photo"
-    src="{{ api_host }}/v1/images/{{ data.photo.id }}/{{ size }}"
+    src="{{ api_host }}/v1/images/{{ size }}/{{ data.photo.id }}"
     alt="{{ data.photo.title }}"
     hx-get="/one_photo/{{ collection_route.name }}/{{ data.photo.id }}"
     hx-push-url="/photography/{{ collection_route.name }}/{{ data.photo.id }}"


### PR DESCRIPTION
Besides using the already cached images in memory, now the service returns `304` when the client sends the `E-Tag` header that matches the `md5` signature of the cached image. This avoids copying the `u8` bytes around as well as saving network transfer, as the Browser skips downloading the image altogether as it uses the browser cache.