### PR TITLE
Webp images

### DIFF
--- a/.cargo/config.toml.example
+++ b/.cargo/config.toml.example
@@ -3,10 +3,19 @@ RUST_DEBUG = "1"
 RUST_LOG = "api_victorhqc_com=debug,cli_victorhqc_com=debug,web_victorhqc_com=debug,sqlx::query=debug,rocket=info"
 ROCKET_CACHED_PHOTO_TAGS = "comma,separated,tags"
 
-AWS_ACCESS_KEY_ID = "<AWS_ACCESS_KEY_ID>"
-AWS_SECRET_ACCESS_KEY = "<AWS_SECRET_ACCESS_KEY>"
-AWS_REGION = "eu-central-1"
-AWS_BUCKET_NAME = "victorhqc.com-development"
+PRODUCTION_AWS_ACCESS_KEY_ID = "<AWS_ACCESS_KEY_ID>"
+PRODUCTION_AWS_SECRET_ACCESS_KEY = "<AWS_SECRET_ACCESS_KEY>"
+PRODUCTION_AWS_REGION = "eu-central-1"
+PRODUCTION_AWS_BUCKET_NAME = "victorhqc.com-development"
+
+DEVELOPMENT_AWS_ACCESS_KEY_ID = "<AWS_ACCESS_KEY_ID>"
+DEVELOPMENT_AWS_SECRET_ACCESS_KEY = "<AWS_SECRET_ACCESS_KEY>"
+DEVELOPMENT_AWS_REGION = "eu-central-1"
+DEVELOPMENT_AWS_BUCKET_NAME = "victorhqc.com-development"
+
+WEB_ROOT = "web/"
+WEB_API_HOST = "http://localhost:7878"
+WEB_PORT = "7879"
 
 [target.x86_64-unknown-linux-musl]
 linker = "x86_64-linux-musl-gcc"

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,7 @@ web/static/
 web/regexes.yaml
 *.zip
 
+__debug_compression__
+*.jpg
 *.jpg
 *.webp

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ stress-tests/benchmark.web.yml
 web/static/
 web/regexes.yaml
 *.zip
+
+*.jpg
+*.webp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,6 +1309,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "tokio",
+ "webp",
  "winapi",
 ]
 
@@ -2821,6 +2822,16 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libwebp-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54cd30df7c7165ce74a456e4ca9732c603e8dc5e60784558c1c6dc047f876733"
+dependencies = [
+ "cc",
+ "glob",
 ]
 
 [[package]]
@@ -5544,6 +5555,16 @@ dependencies = [
  "uuid",
  "walkdir",
  "zip",
+]
+
+[[package]]
+name = "webp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f53152f51fb5af0c08484c33d16cca96175881d1f3dec068c23b31a158c2d99"
+dependencies = [
+ "image",
+ "libwebp-sys",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This website hosts my basic information as well as my photography portfolio. It
 started as a simple idea and it evolved into a fairly complex application that
 is in the over-engineered side. However, it was very satisfying to build, I
 learned a few new things and I'm happy to see that is 90% Rust, although I had
-to move the photo stack js code into a different repository to keep it JS from
-taking over :)
+to move the [photo stack js](https://github.com/victorhqc/victorhqc.com.libs)
+code into a different repository to keep it JS from taking over :)
 
 <img src="screenshots/index.png" height="400" />
 

--- a/api/build.rs
+++ b/api/build.rs
@@ -12,7 +12,16 @@ fn main() {
     let db_file = crate_dir.join("api_victorhqc_com.db");
 
     println!("cargo:rerun-if-changed=build.rs"); // Re-run build if build.rs changes
-    println!("cargo::rerun-if-changed={}", migrations_dir.display()); // Re-run if migrations change
+    println!("cargo:rerun-if-changed={}", migrations_dir.display()); // Re-run if migrations change
+
+    #[cfg(debug_assertions)]
+    {
+        build_aws_keys("DEVELOPMENT_");
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        build_aws_keys("PRODUCTION_");
+    }
 
     if let Err(e) = build_api_db(&db_file, &migrations_dir) {
         eprintln!("Failed to build DB: {}", e);
@@ -56,9 +65,28 @@ fn build_api_db(db_file: &Path, migrations_dir: &Path) -> Result<(), Box<dyn std
     println!("SQLite DB created at {}", db_file.display());
     println!("DATABASE_URL={}", db_url);
 
-    println!("cargo::rustc-env=ROCKET_DATABASE_URL={}", db_url);
-    println!("cargo::rustc-env=DATABASE_URL={}", db_url);
+    println!("cargo:rustc-env=ROCKET_DATABASE_URL={}", db_url);
+    println!("cargo:rustc-env=DATABASE_URL={}", db_url);
     println!("--");
 
     Ok(())
+}
+
+fn build_aws_keys(prefix: &str) {
+    let access_key =
+        std::env::var(format!("{}AWS_ACCESS_KEY_ID", prefix)).unwrap_or("".to_string());
+    println!("cargo:rustc-env=AWS_ACCESS_KEY_ID={}", access_key);
+
+    let secret_access_key =
+        std::env::var(format!("{}AWS_SECRET_ACCESS_KEY", prefix)).unwrap_or("".to_string());
+    println!(
+        "cargo:rustc-env=AWS_SECRET_ACCESS_KEY={}",
+        secret_access_key
+    );
+
+    let region = std::env::var(format!("{}AWS_REGION", prefix)).unwrap_or("".to_string());
+    println!("cargo:rustc-env=AWS_REGION={}", region);
+
+    let bucket_name = std::env::var(format!("{}AWS_BUCKET_NAME", prefix)).unwrap_or("".to_string());
+    println!("cargo:rustc-env=AWS_BUCKET_NAME={}", bucket_name);
 }

--- a/api/src/routes/images.rs
+++ b/api/src/routes/images.rs
@@ -19,10 +19,11 @@ use snafu::prelude::*;
 use std::io::Cursor;
 use std::str::FromStr;
 
-#[get("/images/<size>/<id>")]
+#[get("/images/<size>/<id>?<kind>")]
 pub async fn get_image(
     size: &str,
     id: &str,
+    kind: Option<&str>,
     state: &State<AppState>,
     if_none_match: IfNoneMatch,
 ) -> Result<ImageResponse, Error> {
@@ -32,6 +33,11 @@ pub async fn get_image(
 
     let img_size: ImageSize = ImageSize::from_str(size).context(SizeSnafu {
         size: size.to_string(),
+    })?;
+
+    let kind = kind.map_or("webp", |k| k);
+    let img_kind: ImageType = ImageType::from_str(kind).context(KindSnafu {
+        kind: kind.to_string(),
     })?;
 
     debug!("id: {}", id);
@@ -48,9 +54,16 @@ pub async fn get_image(
 
     let photo = Photo::find_by_id(&mut conn, id).await.context(PhotoSnafu)?;
 
-    let (etag, data) = cache.get(photo, &img_size).await.context(CacheSnafu)?;
+    let (etag, data) = cache
+        .get(photo, &img_kind, &img_size)
+        .await
+        .context(CacheSnafu)?;
 
-    Ok(ImageResponse { data, etag })
+    Ok(ImageResponse {
+        data,
+        etag,
+        kind: img_kind,
+    })
 }
 
 pub struct ImageResponse {
@@ -61,8 +74,13 @@ pub struct ImageResponse {
 
 impl<'r> Responder<'r, 'static> for ImageResponse {
     fn respond_to(self, _: &'r Request<'_>) -> Result<Response<'static>, Status> {
+        let content_type = match self.kind {
+            ImageType::Jpeg => "image/jpeg",
+            ImageType::Webp => "image/webp",
+        };
+
         Response::build()
-            .header(Header::new("Content-Type", "image/jpeg"))
+            .header(Header::new("Content-Type", content_type))
             .header(Header::new("ETag", self.etag))
             .header(Header::new("Cache-Control", "public, max-age=31536000"))
             .sized_body(self.data.len(), Cursor::new(self.data))
@@ -90,6 +108,12 @@ pub enum Error {
         source: ParseError,
     },
 
+    #[snafu(display("Invalid type '{}': {}", kind, source))]
+    Kind {
+        kind: String,
+        source: ParseError,
+    },
+
     #[snafu(display("Failed to get connection: {}", source))]
     Connection {
         source: SqlxError,
@@ -112,6 +136,7 @@ impl<'r> Responder<'r, 'static> for Error {
     fn respond_to(self, _: &'r rocket::Request<'_>) -> rocket::response::Result<'static> {
         let status: Status = match &self {
             Error::Size { .. } => Status::InternalServerError,
+            Error::Kind { .. } => Status::BadRequest,
             Error::Connection { .. } => Status::InternalServerError,
             Error::Photo { .. } => Status::InternalServerError,
             Error::Cache { source } => match source {
@@ -141,6 +166,10 @@ impl Serialize for Error {
         match self {
             Error::Size { size, .. } => {
                 state.serialize_field("kind", &format!("Invalid Size: {}", size))?;
+                state.serialize_field("message", &self.to_string())?;
+            }
+            Error::Kind { kind, .. } => {
+                state.serialize_field("kind", &format!("Invalid type: {}", kind))?;
                 state.serialize_field("message", &self.to_string())?;
             }
             Error::Connection { .. } => {

--- a/api/src/routes/images.rs
+++ b/api/src/routes/images.rs
@@ -1,7 +1,7 @@
 use crate::cache::image_cache::Error as CacheError;
 use crate::AppState;
 use core_victorhqc_com::{
-    aws::image_size::{Error as ParseError, ImageSize},
+    aws::image_size::{Error as ParseError, ImageSize, ImageType},
     models::photo::{db::Error as PhotoDbError, Photo},
     sqlx::Error as SqlxError,
 };
@@ -55,6 +55,7 @@ pub async fn get_image(
 
 pub struct ImageResponse {
     data: Vec<u8>,
+    kind: ImageType,
     etag: String,
 }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,6 +19,7 @@ serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
 tokio = { workspace = true, features = ["full"] }
+webp = "0.3.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winbase"] }

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -3,10 +3,15 @@ fn main() {
     let crate_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     println!("cargo:rerun-if-changed=build.rs"); // Re-run build if build.rs changes
     #[cfg(debug_assertions)]
-    let db_file = crate_dir.join("..").join("api").join("development.db");
+    let db_file = crate_dir
+        .parent()
+        .unwrap()
+        .join("api")
+        .join("development.db");
     #[cfg(not(debug_assertions))]
     let db_file = crate_dir
-        .join("..")
+        .parent()
+        .unwrap()
         .join("api")
         .join("api_victorhqc_com.db");
     let db_url = format!("sqlite:{}", db_file.display());

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -15,5 +15,33 @@ fn main() {
         .join("api")
         .join("api_victorhqc_com.db");
     let db_url = format!("sqlite:{}", db_file.display());
-    println!("cargo::rustc-env=DATABASE_URL={}", db_url);
+    println!("cargo:rustc-env=DATABASE_URL={}", db_url);
+
+    #[cfg(debug_assertions)]
+    {
+        build_aws_keys("DEVELOPMENT_");
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        build_aws_keys("PRODUCTION_");
+    }
+}
+
+fn build_aws_keys(prefix: &str) {
+    let access_key =
+        std::env::var(format!("{}AWS_ACCESS_KEY_ID", prefix)).unwrap_or("".to_string());
+    println!("cargo:rustc-env=AWS_ACCESS_KEY_ID={}", access_key);
+
+    let secret_access_key =
+        std::env::var(format!("{}AWS_SECRET_ACCESS_KEY", prefix)).unwrap_or("".to_string());
+    println!(
+        "cargo:rustc-env=AWS_SECRET_ACCESS_KEY={}",
+        secret_access_key
+    );
+
+    let region = std::env::var(format!("{}AWS_REGION", prefix)).unwrap_or("".to_string());
+    println!("cargo:rustc-env=AWS_REGION={}", region);
+
+    let bucket_name = std::env::var(format!("{}AWS_BUCKET_NAME", prefix)).unwrap_or("".to_string());
+    println!("cargo:rustc-env=AWS_BUCKET_NAME={}", bucket_name);
 }

--- a/cli/src/commands/debug_compression.rs
+++ b/cli/src/commands/debug_compression.rs
@@ -1,0 +1,59 @@
+use crate::{
+    photo::process::{Error as ProcessPhotoError, ProcessedPhoto},
+    utils::is_valid_extension,
+};
+use image::error::ImageError;
+use log::debug;
+use snafu::prelude::*;
+use std::path::Path;
+
+pub async fn debug_compression(src: &Path) -> Result<(), Error> {
+    if !is_valid_extension(src) {
+        return Err(Error::Extension {
+            path: src.to_str().unwrap().to_string(),
+        });
+    }
+
+    let debug_dir = std::path::Path::new("__debug_compression__");
+    if !std::fs::exists(debug_dir).unwrap() {
+        std::fs::create_dir(debug_dir).unwrap();
+    }
+
+    debug!("Opening photo");
+    let img = image::open(src).context(OpenSnafu)?;
+
+    let mut processed: Vec<ProcessedPhoto> = Vec::new();
+
+    debug!("Processing HD");
+    processed.push(ProcessedPhoto::build_hd(&img).context(ProcessSnafu)?);
+    debug!("Processing MD");
+    processed.push(ProcessedPhoto::build_md(&img).context(ProcessSnafu)?);
+    debug!("Processing SM");
+    processed.push(ProcessedPhoto::build_sm(&img).context(ProcessSnafu)?);
+
+    for photo in processed {
+        let target_jpeg = debug_dir
+            .join(photo.size.to_string())
+            .with_extension("jpeg");
+        let target_webp = debug_dir
+            .join(photo.size.to_string())
+            .with_extension("webp");
+
+        std::fs::write(target_jpeg, &*photo.buffers.jpeg).expect("Failed to write JPEG");
+        std::fs::write(target_webp, &*photo.buffers.webp).expect("Failed to write JPEG");
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Invalid file, wrong extension: {}", path))]
+    Extension { path: String },
+
+    #[snafu(display("Unable to open file: {}", source))]
+    Open { source: ImageError },
+
+    #[snafu(display("Failed to process photo: {}", source))]
+    Process { source: ProcessPhotoError },
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,3 +1,7 @@
 mod create;
+#[cfg(debug_assertions)]
+mod debug_compression;
 
 pub use create::*;
+#[cfg(debug_assertions)]
+pub use debug_compression::*;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -41,6 +41,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 })
                 .unwrap();
         }
+        #[cfg(debug_assertions)]
+        Commands::DebugCompression { source } => {
+            let src = Path::new(&source);
+
+            commands::debug_compression(src).await.unwrap();
+        }
     }
 
     Ok(())
@@ -56,6 +62,11 @@ struct Cli {
 enum Commands {
     #[command(arg_required_else_help = true)]
     Create {
+        #[arg(short, long)]
+        source: String,
+    },
+    #[cfg(debug_assertions)]
+    DebugCompression {
         #[arg(short, long)]
         source: String,
     },

--- a/cli/src/photo/build_images.rs
+++ b/cli/src/photo/build_images.rs
@@ -39,9 +39,9 @@ static DRAWER: Emoji<'_, '_> = Emoji("🗃️  ", "");
 
 /// Creates buffers based on a path with a valid JPG image.
 /// These buffers do not have exif metadata and have the following sizes:
-/// - HD: 40% of the original image with JPEG quality of 80 and a WEBP (lossy) with 80% quality
-/// - MD: 25% of the original image with JPEG quality of 75 and a WEBP (lossy) with 75% quality
-/// - SM: 15% of the original image with JPEG quality of 70 and a WEBP (lossy) with 30% quality
+/// - HD: 1080px image JPEG quality of 80 and a WEBP (lossy) with 75% quality
+/// - MD: 720px image JPEG quality of 80 and a WEBP (lossy) with 75% quality
+/// - SM: 480px image JPEG quality of 80 and a WEBP (lossy) with 70% quality
 pub fn start_build(path: &Path, tx: Sender<ImageProcess>) -> Result<MainHandle, Error> {
     if !is_valid_extension(path) {
         return Err(Error::Extension {

--- a/cli/src/photo/mod.rs
+++ b/cli/src/photo/mod.rs
@@ -1,2 +1,3 @@
 pub mod build_images;
+pub mod process;
 pub mod upload;

--- a/cli/src/photo/process.rs
+++ b/cli/src/photo/process.rs
@@ -1,0 +1,118 @@
+use core::f32;
+use core_victorhqc_com::aws::image_size::ImageSize;
+use image::{
+    codecs::jpeg::JpegEncoder, error::ImageError, imageops::FilterType::Lanczos3, DynamicImage,
+    GenericImageView,
+};
+use log::debug;
+use snafu::prelude::*;
+use std::io::Cursor;
+
+pub struct ProcessedPhoto {
+    pub size: ImageSize,
+    pub buffers: ProcessedBuffers,
+}
+
+pub struct ProcessedBuffers {
+    pub jpeg: Vec<u8>,
+    pub webp: Vec<u8>,
+}
+
+impl ProcessedPhoto {
+    pub fn build_hd(img: &DynamicImage) -> Result<Self, Error> {
+        Self::build(img, ImageSize::Hd, 1080, 75f32)
+    }
+
+    pub fn build_md(img: &DynamicImage) -> Result<Self, Error> {
+        Self::build(img, ImageSize::Md, 760, 75f32)
+    }
+
+    pub fn build_sm(img: &DynamicImage) -> Result<Self, Error> {
+        Self::build(img, ImageSize::Sm, 420, 70f32)
+    }
+
+    fn build(
+        img: &DynamicImage,
+        size: ImageSize,
+        wanted_height: i32,
+        compression: f32,
+    ) -> Result<Self, Error> {
+        debug!("Resizing {} Image", size);
+        let resized = resize_with_known_dimensions(img, wanted_height);
+
+        debug!("Converting to Webp");
+        let webp = convert_to_webp(&resized, compression)?;
+
+        debug!("Converting to JPEG");
+        let jpeg = compress(&resized, compression)?;
+
+        Ok(ProcessedPhoto {
+            size,
+            buffers: ProcessedBuffers { webp, jpeg },
+        })
+    }
+}
+
+/// This Function will resize the image to a known height. However, the height changes depending on
+/// the photo. The height will always be the small side of the rectangle, meaning that it will be
+/// the regular height when it is in landscape, but in a portrait photo, the height would be
+/// technically, the width. Why this way? To keep the image sizes consistant.
+fn resize_with_known_dimensions(img: &DynamicImage, wanted_height: i32) -> DynamicImage {
+    let (width, height) = img.dimensions();
+
+    let is_landscape = width > height;
+
+    debug!("Is landscape? {}", is_landscape);
+
+    let current_height = if is_landscape { height } else { width };
+    debug!("Current height: {}", current_height);
+
+    // To figure out the wanted width we must calculate how much percentage the wanted height
+    // represents compared with the current height. If the current height is 10800 and the wanted
+    // height is 1080, then the percentage would be 10% (1080 * 100 / 10800) so we should calculate
+    // the width as 10% of its current size.
+    let percentage: f32 = (wanted_height as f32 * 100.00) / current_height as f32;
+    debug!("Percentage to shrink: {}", percentage);
+
+    resize(img, percentage / 100.00)
+}
+
+fn resize(img: &DynamicImage, percentage: f32) -> DynamicImage {
+    let (width, height) = img.dimensions();
+
+    let width = (width as f32 * percentage).round() as u32;
+    let height = (height as f32 * percentage).round() as u32;
+
+    debug!("New dimensions: {} height, {} width", height, width);
+
+    img.resize_exact(width, height, Lanczos3)
+}
+
+fn compress(img: &DynamicImage, quality: f32) -> Result<Vec<u8>, Error> {
+    let mut buffer: Vec<u8> = Vec::new();
+    let mut cursor = Cursor::new(&mut buffer);
+
+    let quality: u8 = quality as u8;
+    let encoder = JpegEncoder::new_with_quality(&mut cursor, quality);
+    img.write_with_encoder(encoder).context(JpegSnafu)?;
+
+    Ok(buffer)
+}
+
+fn convert_to_webp(img: &DynamicImage, quality: f32) -> Result<Vec<u8>, Error> {
+    let encoder = webp::Encoder::from_image(img).map_err(|e| Error::Webp {
+        error: e.to_string(),
+    })?;
+    let webp: webp::WebPMemory = encoder.encode(quality);
+
+    Ok(webp.to_vec())
+}
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to encode JPEG: {}", source))]
+    Jpeg { source: ImageError },
+
+    #[snafu(display("Failed to encode WEBP: {}", error))]
+    Webp { error: String },
+}

--- a/cli/src/photo/process.rs
+++ b/cli/src/photo/process.rs
@@ -24,11 +24,11 @@ impl ProcessedPhoto {
     }
 
     pub fn build_md(img: &DynamicImage) -> Result<Self, Error> {
-        Self::build(img, ImageSize::Md, 760, 75f32)
+        Self::build(img, ImageSize::Md, 720, 75f32)
     }
 
     pub fn build_sm(img: &DynamicImage) -> Result<Self, Error> {
-        Self::build(img, ImageSize::Sm, 420, 70f32)
+        Self::build(img, ImageSize::Sm, 480, 70f32)
     }
 
     fn build(

--- a/cli/src/photo/upload.rs
+++ b/cli/src/photo/upload.rs
@@ -1,27 +1,70 @@
 use crate::photo::build_images::ImageBuffers;
 use core_victorhqc_com::{
-    aws::{image_size::ImageSize, photo::Error as UploadError, S3},
+    aws::{
+        image_size::{ImageSize, ImageType},
+        photo::Error as UploadError,
+        S3,
+    },
     models::photo::Photo,
 };
 use snafu::prelude::*;
 
 pub async fn upload(photo: &Photo, s3: &S3, buffers: ImageBuffers) -> Result<(), Error> {
-    let (result_hd, result_md, result_sm) = futures::join!(
-        s3.upload_to_aws_s3((photo, &ImageSize::Hd), buffers.hd),
-        s3.upload_to_aws_s3((photo, &ImageSize::Md), buffers.md),
-        s3.upload_to_aws_s3((photo, &ImageSize::Sm), buffers.sm),
+    let (result_hd, result_hd_webp, result_md, result_md_webp, result_sm, result_sm_webp) = futures::join!(
+        s3.upload_to_aws_s3(
+            (photo, &ImageSize::Hd, Some(&ImageType::Jpeg)),
+            buffers.hd.jpeg
+        ),
+        s3.upload_to_aws_s3(
+            (photo, &ImageSize::Hd, Some(&ImageType::Webp)),
+            buffers.hd.webp
+        ),
+        s3.upload_to_aws_s3(
+            (photo, &ImageSize::Md, Some(&ImageType::Jpeg)),
+            buffers.md.jpeg
+        ),
+        s3.upload_to_aws_s3(
+            (photo, &ImageSize::Md, Some(&ImageType::Webp)),
+            buffers.md.webp
+        ),
+        s3.upload_to_aws_s3(
+            (photo, &ImageSize::Sm, Some(&ImageType::Jpeg)),
+            buffers.sm.jpeg
+        ),
+        s3.upload_to_aws_s3(
+            (photo, &ImageSize::Sm, Some(&ImageType::Webp)),
+            buffers.sm.webp
+        ),
     );
 
     result_hd.context(UploadSnafu {
         size: ImageSize::Hd,
+        kind: ImageType::Jpeg,
+    })?;
+
+    result_hd_webp.context(UploadSnafu {
+        size: ImageSize::Hd,
+        kind: ImageType::Webp,
     })?;
 
     result_md.context(UploadSnafu {
         size: ImageSize::Md,
+        kind: ImageType::Jpeg,
+    })?;
+
+    result_md_webp.context(UploadSnafu {
+        size: ImageSize::Md,
+        kind: ImageType::Webp,
     })?;
 
     result_sm.context(UploadSnafu {
         size: ImageSize::Sm,
+        kind: ImageType::Jpeg,
+    })?;
+
+    result_sm_webp.context(UploadSnafu {
+        size: ImageSize::Sm,
+        kind: ImageType::Webp,
     })?;
 
     Ok(())
@@ -29,9 +72,10 @@ pub async fn upload(photo: &Photo, s3: &S3, buffers: ImageBuffers) -> Result<(),
 
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Failed to upload {} Photo: {:?}", size, source))]
+    #[snafu(display("Failed to upload {} photo of type {}: {}", kind, size, source))]
     Upload {
         size: ImageSize,
+        kind: ImageType,
         source: UploadError,
     },
 }

--- a/cli/src/photo/upload.rs
+++ b/cli/src/photo/upload.rs
@@ -11,36 +11,18 @@ use snafu::prelude::*;
 
 pub async fn upload(photo: &Photo, s3: &S3, buffers: ImageBuffers) -> Result<(), Error> {
     let hd_pairs = futures::join!(
-        s3.upload_to_aws_s3(
-            (photo, &ImageSize::Hd, Some(&ImageType::Jpeg)),
-            buffers.hd.jpeg
-        ),
-        s3.upload_to_aws_s3(
-            (photo, &ImageSize::Hd, Some(&ImageType::Webp)),
-            buffers.hd.webp
-        )
+        s3.upload_to_aws_s3((photo, &ImageSize::Hd, &ImageType::Jpeg), buffers.hd.jpeg),
+        s3.upload_to_aws_s3((photo, &ImageSize::Hd, &ImageType::Webp), buffers.hd.webp)
     );
 
     let md_pairs = futures::join!(
-        s3.upload_to_aws_s3(
-            (photo, &ImageSize::Md, Some(&ImageType::Jpeg)),
-            buffers.md.jpeg
-        ),
-        s3.upload_to_aws_s3(
-            (photo, &ImageSize::Md, Some(&ImageType::Webp)),
-            buffers.md.webp
-        )
+        s3.upload_to_aws_s3((photo, &ImageSize::Md, &ImageType::Jpeg), buffers.md.jpeg),
+        s3.upload_to_aws_s3((photo, &ImageSize::Md, &ImageType::Webp), buffers.md.webp)
     );
 
     let sm_pairs = futures::join!(
-        s3.upload_to_aws_s3(
-            (photo, &ImageSize::Sm, Some(&ImageType::Jpeg)),
-            buffers.sm.jpeg
-        ),
-        s3.upload_to_aws_s3(
-            (photo, &ImageSize::Sm, Some(&ImageType::Webp)),
-            buffers.sm.webp
-        ),
+        s3.upload_to_aws_s3((photo, &ImageSize::Sm, &ImageType::Jpeg), buffers.sm.jpeg),
+        s3.upload_to_aws_s3((photo, &ImageSize::Sm, &ImageType::Webp), buffers.sm.webp),
     );
 
     hd_pairs.0.context(UploadSnafu {

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,20 +1,33 @@
 use std::path::PathBuf;
+use std::process::Command;
 
 fn main() {
     let crate_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+
     let migrations_dir = crate_dir.join("migrations");
 
     println!("cargo:rerun-if-changed=build.rs"); // Re-run build if build.rs changes
-    println!("cargo::rerun-if-changed={}", migrations_dir.display()); // Re-run if migrations change
+    println!("cargo:rerun-if-changed={}", migrations_dir.display()); // Re-run if migrations change
 
-    #[cfg(debug_assertions)]
-    let db_file = crate_dir.join("..").join("api").join("development.db");
-    #[cfg(not(debug_assertions))]
-    let db_file = crate_dir
-        .join("..")
-        .join("api")
-        .join("api_victorhqc_com.db");
+    let db_file = crate_dir.join("__DB_FOR_MACROS__.db");
 
     let db_url = format!("sqlite:{}", db_file.display());
-    println!("cargo::rustc-env=DATABASE_URL={}", db_url);
+
+    std::process::Command::new("sqlx")
+        .arg("database")
+        .arg("create")
+        .env("DATABASE_URL", &db_url)
+        .output()
+        .unwrap();
+
+    Command::new("sqlx")
+        .arg("migrate")
+        .arg("run")
+        .arg("--source")
+        .arg(&migrations_dir)
+        .env("DATABASE_URL", &db_url)
+        .output()
+        .unwrap();
+
+    println!("cargo:rustc-env=DATABASE_URL={}", db_url);
 }

--- a/core/src/aws/image_size.rs
+++ b/core/src/aws/image_size.rs
@@ -13,13 +13,29 @@ impl FromStr for ImageSize {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "Hd" => Ok(ImageSize::Hd),
+        match s.to_lowercase().as_str() {
             "hd" => Ok(ImageSize::Hd),
-            "Md" => Ok(ImageSize::Md),
             "md" => Ok(ImageSize::Md),
-            "Sm" => Ok(ImageSize::Sm),
             "sm" => Ok(ImageSize::Sm),
+            _ => Err(Error::Invalid),
+        }
+    }
+}
+
+#[derive(Debug, Display, Clone, PartialEq)]
+pub enum ImageType {
+    Jpeg,
+    Webp,
+}
+
+impl FromStr for ImageType {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "jpeg" => Ok(ImageType::Jpeg),
+            "jpg" => Ok(ImageType::Jpeg),
+            "webp" => Ok(ImageType::Webp),
             _ => Err(Error::Invalid),
         }
     }

--- a/core/src/aws/photo.rs
+++ b/core/src/aws/photo.rs
@@ -15,7 +15,7 @@ pub use aws_sdk_s3::primitives::{ByteStream, ByteStreamError};
 impl S3 {
     pub async fn upload_to_aws_s3(
         &self,
-        data: (&Photo, &ImageSize, Option<&ImageType>),
+        data: (&Photo, &ImageSize, &ImageType),
         buffer: Vec<u8>,
     ) -> Result<PutObjectOutput, Error> {
         let body = ByteStream::from(buffer);
@@ -32,7 +32,7 @@ impl S3 {
 
     pub async fn download_from_aws_s3(
         &self,
-        data: (&Photo, &ImageSize, Option<&ImageType>),
+        data: (&Photo, &ImageSize, &ImageType),
     ) -> Result<GetObjectOutput, Error> {
         self.client
             .get_object()
@@ -44,11 +44,9 @@ impl S3 {
     }
 }
 
-fn key((photo, size, photo_type): (&Photo, &ImageSize, Option<&ImageType>)) -> String {
-    if let Some(t) = photo_type {
-        if t == &ImageType::Webp {
-            return format!("{}_{}_{}", photo.id, t, size);
-        }
+fn key((photo, size, photo_type): (&Photo, &ImageSize, &ImageType)) -> String {
+    if photo_type == &ImageType::Webp {
+        return format!("{}_{}_{}", photo.id, photo_type, size);
     }
 
     format!("{}_{}", photo.id, size)

--- a/core/src/aws/photo.rs
+++ b/core/src/aws/photo.rs
@@ -1,4 +1,4 @@
-use super::image_size::ImageSize;
+use super::image_size::{ImageSize, ImageType};
 use super::S3;
 use crate::models::photo::Photo;
 use aws_sdk_s3::{
@@ -15,7 +15,7 @@ pub use aws_sdk_s3::primitives::{ByteStream, ByteStreamError};
 impl S3 {
     pub async fn upload_to_aws_s3(
         &self,
-        data: (&Photo, &ImageSize),
+        data: (&Photo, &ImageSize, Option<&ImageType>),
         buffer: Vec<u8>,
     ) -> Result<PutObjectOutput, Error> {
         let body = ByteStream::from(buffer);
@@ -32,7 +32,7 @@ impl S3 {
 
     pub async fn download_from_aws_s3(
         &self,
-        data: (&Photo, &ImageSize),
+        data: (&Photo, &ImageSize, Option<&ImageType>),
     ) -> Result<GetObjectOutput, Error> {
         self.client
             .get_object()
@@ -44,7 +44,13 @@ impl S3 {
     }
 }
 
-fn key((photo, size): (&Photo, &ImageSize)) -> String {
+fn key((photo, size, photo_type): (&Photo, &ImageSize, Option<&ImageType>)) -> String {
+    if let Some(t) = photo_type {
+        if t == &ImageType::Webp {
+            return format!("{}_{}_{}", photo.id, t, size);
+        }
+    }
+
     format!("{}_{}", photo.id, size)
 }
 

--- a/core/src/models/exif_meta/from_exif/date_taken.rs
+++ b/core/src/models/exif_meta/from_exif/date_taken.rs
@@ -3,7 +3,7 @@ use crate::models::exif_meta::DateTaken;
 use log::trace;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use time::{Date, Month, OffsetDateTime, Time, UtcOffset};
+use time::{Date, Month};
 
 impl FromExifData for DateTaken {
     fn from_exif(data: &[ExifData]) -> Option<Self> {
@@ -17,39 +17,19 @@ impl FromExifData for DateTaken {
         static RE_DATE: Lazy<Regex> = Lazy::new(|| {
             Regex::new(r"(?<year>[0-9]{4})[-:](?<month>[09]{2})[-:](?<day>[0-9]{2})").unwrap()
         });
-        static RE_TIME: Lazy<Regex> = Lazy::new(|| {
-            Regex::new(r"(?<hour>[0-9]{2}):(?<minute>[0-9]{2}):(?<second>[0-9]{2})").unwrap()
-        });
-        static RE_OFFSET: Lazy<Regex> =
-            Lazy::new(|| Regex::new(r"(?<hour>[+\-0-9]{3}):(?<minute>[0-9]{2})").unwrap());
 
         let caps = RE.captures(exif.value())?;
         let date = &caps["date"];
-        let time = &caps["time"];
-        let offset = &caps["offset"];
 
         let date_caps = RE_DATE.captures(date)?;
         let year = date_caps["year"].parse::<i32>().ok()?;
         let month = date_caps["month"].parse::<i32>().ok()?;
         let day = date_caps["day"].parse::<i32>().ok()?;
 
-        let time_caps = RE_TIME.captures(time)?;
-        let hour = time_caps["hour"].parse::<i32>().ok()?;
-        let minute = time_caps["minute"].parse::<i32>().ok()?;
-        let second = time_caps["second"].parse::<i32>().ok()?;
-
-        let offset_caps = RE_OFFSET.captures(offset)?;
-        let hour_offset = offset_caps["hour"].parse::<i32>().ok()?;
-        let minute_offset = offset_caps["minute"].parse::<i32>().ok()?;
-
         let date = Date::from_calendar_date(year, Month::try_from(month as u8).unwrap(), day as u8)
             .ok()?;
-        let time = Time::from_hms(hour as u8, minute as u8, second as u8).ok()?;
-        let offset = UtcOffset::from_hms(hour_offset as i8, minute_offset as i8, 0).ok()?;
 
-        let value = OffsetDateTime::new_in_offset(date, time, offset);
-
-        Some(DateTaken(value))
+        Some(DateTaken(date))
     }
 }
 
@@ -64,11 +44,8 @@ mod tests {
             "2024:09:12 18:55:14.13+02:00",
         )];
         let date = Date::from_calendar_date(2024, Month::September, 12).unwrap();
-        let time = Time::from_hms(18, 55, 14).unwrap();
-        let offset = UtcOffset::from_hms(2, 0, 0).unwrap();
-        let date_time = OffsetDateTime::new_in_offset(date, time, offset);
 
-        assert_eq!(DateTaken::from_exif(&exif), Some(DateTaken(date_time)));
+        assert_eq!(DateTaken::from_exif(&exif), Some(DateTaken(date)));
     }
 
     #[test]
@@ -78,11 +55,8 @@ mod tests {
             "2024:09:12 18:55:14.13-07:30",
         )];
         let date = Date::from_calendar_date(2024, Month::September, 12).unwrap();
-        let time = Time::from_hms(18, 55, 14).unwrap();
-        let offset = UtcOffset::from_hms(-7, 30, 0).unwrap();
-        let date_time = OffsetDateTime::new_in_offset(date, time, offset);
 
-        assert_eq!(DateTaken::from_exif(&exif), Some(DateTaken(date_time)));
+        assert_eq!(DateTaken::from_exif(&exif), Some(DateTaken(date)));
     }
 
     #[test]

--- a/core/src/models/exif_meta/from_exif/photography_details.rs
+++ b/core/src/models/exif_meta/from_exif/photography_details.rs
@@ -73,7 +73,7 @@ impl FromExifData for PhotographyDetails {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use time::{Date, Month, OffsetDateTime, Time, UtcOffset};
+    use time::{Date, Month};
 
     #[test]
     fn it_parses_photography_details_from_exif() {
@@ -93,16 +93,13 @@ mod tests {
         ];
 
         let date = Date::from_calendar_date(2024, Month::September, 12).unwrap();
-        let time = Time::from_hms(18, 55, 14).unwrap();
-        let offset = UtcOffset::from_hms(2, 0, 0).unwrap();
-        let date_time = OffsetDateTime::new_in_offset(date, time, offset);
 
         assert_eq!(
             PhotographyDetails::from_exif(&exif),
             Some(PhotographyDetails {
                 rating: Rating(3),
                 city: Some(City("Berlin".to_string())),
-                date_taken: Some(DateTaken(date_time)),
+                date_taken: Some(DateTaken(date)),
                 camera_name: "X-T5".to_string(),
                 lens_name: Some("XF23mmF1.4 R LM WR".to_string()),
                 aperture: Aperture(2.8),

--- a/core/src/models/exif_meta/mod.rs
+++ b/core/src/models/exif_meta/mod.rs
@@ -6,7 +6,7 @@ use crate::models::fujifilm::FujifilmRecipe;
 use crate::models::photo::Photo;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display as EnumDisplay;
-use time::OffsetDateTime;
+use time::Date;
 use uuid::Uuid;
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -55,7 +55,7 @@ pub struct PhotographyDetails {
 pub struct Rating(pub i8);
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct DateTaken(pub OffsetDateTime);
+pub struct DateTaken(pub Date);
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct City(pub String);

--- a/core/src/models/photo/db.rs
+++ b/core/src/models/photo/db.rs
@@ -81,8 +81,8 @@ impl Photo {
 }
 
 async fn find_by_id(conn: &mut SqliteConnection, id: &str) -> Result<Photo, Error> {
-    // TODO: Move back to macro. Fails to compile in IDE because fails to find DB
-    let photo = sqlx::query_as::<_, DBPhoto>(
+    let photo = sqlx::query_as!(
+        DBPhoto,
         r#"
     SELECT
         id,
@@ -100,8 +100,8 @@ async fn find_by_id(conn: &mut SqliteConnection, id: &str) -> Result<Photo, Erro
     ORDER BY
         created_at ASC
     "#,
+        id
     )
-    .bind(id)
     .fetch_one(conn)
     .await
     .context(SqlxSnafu)?;
@@ -113,8 +113,10 @@ async fn find_by_filename(
     conn: &mut SqliteConnection,
     path: &Path,
 ) -> Result<Option<Photo>, Error> {
-    // TODO: Move back to macro. Fails to compile in IDE because fails to find DB
-    let photo = sqlx::query_as::<_, DBPhoto>(
+    let filename = path.file_name().unwrap().to_str().unwrap();
+
+    let photo = sqlx::query_as!(
+        DBPhoto,
         r#"
     SELECT
         id,
@@ -132,8 +134,8 @@ async fn find_by_filename(
     ORDER BY
         created_at ASC
     "#,
+        filename
     )
-    .bind(path.file_name().unwrap().to_str().unwrap())
     .fetch_optional(conn)
     .await
     .context(SqlxSnafu)?;
@@ -146,8 +148,8 @@ async fn find_by_filename(
 }
 
 async fn find_all(conn: &mut SqliteConnection) -> Result<Vec<Photo>, Error> {
-    // TODO: Move back to macro. Fails to compile in IDE because fails to find DB
-    let photos = sqlx::query_as::<_, DBPhoto>(
+    let photos = sqlx::query_as!(
+        DBPhoto,
         r#"
     SELECT
         id,
@@ -239,19 +241,19 @@ async fn find_by_tag_ids(
 async fn insert(conn: &mut SqliteConnection, photo: DBPhoto) -> Result<String, Error> {
     let id = photo.id.clone();
 
-    sqlx::query(
+    sqlx::query!(
         r#"
     INSERT INTO photos (id, title, filename, filetype, created_at, updated_at, deleted)
     VALUES (?, ?, ?, ?, ?, ?, ?)
     "#,
+        photo.id,
+        photo.title,
+        photo.filename,
+        photo.filetype,
+        photo.created_at,
+        photo.updated_at,
+        photo.deleted
     )
-    .bind(&photo.id)
-    .bind(&photo.title)
-    .bind(&photo.filename)
-    .bind(&photo.filetype)
-    .bind(&photo.created_at)
-    .bind(&photo.updated_at)
-    .bind(photo.deleted)
     .execute(conn)
     .await
     .context(SqlxSnafu)?;
@@ -262,15 +264,15 @@ async fn insert(conn: &mut SqliteConnection, photo: DBPhoto) -> Result<String, E
 async fn attach_tag(conn: &mut SqliteConnection, photo: &Photo, tag: &Tag) -> Result<(), Error> {
     let id = Uuid::new_v4().to_string();
 
-    sqlx::query(
+    sqlx::query!(
         r#"
     INSERT INTO photo_tags (id, photo_id, tag_id)
     VALUES (?, ?, ?)
     "#,
+        id,
+        photo.id,
+        tag.id
     )
-    .bind(id)
-    .bind(&photo.id)
-    .bind(&tag.id)
     .execute(conn)
     .await
     .context(SqlxSnafu)?;

--- a/core/src/models/photo/db.rs
+++ b/core/src/models/photo/db.rs
@@ -283,31 +283,29 @@ async fn attach_tag(conn: &mut SqliteConnection, photo: &Photo, tag: &Tag) -> Re
 impl TryFrom<DBPhoto> for Photo {
     type Error = Error;
 
-    fn try_from(photo: DBPhoto) -> Result<Self, Error> {
-        let filetype = FileType::from_str(&photo.filetype).context(FileTypeSnafu)?;
+    fn try_from(value: DBPhoto) -> Result<Self, Error> {
+        let filetype = FileType::from_str(&value.filetype).context(FileTypeSnafu)?;
 
         let created_at = {
-            // Time is in milliseconds
-            let timestamp = photo.created_at.0 / 1000;
+            let timestamp = value.created_at.0 / 1000;
 
             OffsetDateTime::from_unix_timestamp(timestamp).context(TimestampSnafu)?
         };
 
         let updated_at = {
-            // Time is in milliseconds
-            let timestamp = photo.updated_at.0 / 1000;
+            let timestamp = value.updated_at.0 / 1000;
 
             OffsetDateTime::from_unix_timestamp(timestamp).context(TimestampSnafu)?
         };
 
         Ok(Photo {
-            id: photo.id,
-            title: photo.title,
-            filename: photo.filename,
+            id: value.id,
+            title: value.title,
+            filename: value.filename,
             filetype,
             created_at,
             updated_at,
-            deleted: photo.deleted,
+            deleted: value.deleted,
         })
     }
 }

--- a/core/src/models/tag/db.rs
+++ b/core/src/models/tag/db.rs
@@ -206,17 +206,17 @@ async fn find_by_photo_ids(
 async fn insert(conn: &mut SqliteConnection, tag: &DBTag) -> Result<String, Error> {
     let id = tag.id.clone();
 
-    sqlx::query(
+    sqlx::query!(
         r#"
     INSERT INTO tags(id, name, created_at, updated_at, deleted)
     VALUES (?, ?, ?, ?, ?)
     "#,
+        tag.id,
+        tag.name,
+        tag.created_at,
+        tag.updated_at,
+        tag.deleted
     )
-    .bind(&tag.id)
-    .bind(&tag.name)
-    .bind(&tag.created_at)
-    .bind(&tag.updated_at)
-    .bind(tag.deleted)
     .execute(conn)
     .await
     .context(SqlxSnafu)?;


### PR DESCRIPTION
- Upload & Download WEBP Images
- More consistent compression. Regardless of the original photo, the result size will always be the same.
- Serve WEBP Images by default
- Cache both WEBP and JPEG images
- Fix SQLX macros issue, finally I'm able to use them in my IDE without them failing.
- Dynamic AWS Keys. This removes the possibility of uploading/downloading photos to prod from dev build, as well as baking the keys in the binary, removing additional configuration in production.

**WARNING**

The images will need to be re-uploaded to add the WEBP format and improve the compression